### PR TITLE
Option usable when table create

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ```elixir
 def deps do
   [
-    {:blanton, "~> 0.1.0"}
+    {:blanton, "~> 0.1.1"}
   ]
 end
 ```
@@ -36,7 +36,7 @@ config: :blanton,
   - [x] Delete
 - Table
   - [x] Create
-  - [ ] Create(Partitioning)
+  - [x] Create(Option usable)
   - [x] Update
   - [x] Delete
 - Record

--- a/lib/blanton.ex
+++ b/lib/blanton.ex
@@ -1,2 +1,4 @@
 defmodule Blanton do
+  alias Blanton.MixProject
+  def version, do: MixProject.project[:version]
 end

--- a/lib/blanton/table.ex
+++ b/lib/blanton/table.ex
@@ -235,6 +235,41 @@ defmodule Blanton.Table do
     new(project_id(), dataset_id(), name, columns)
   end
 
+  @spec new(String.t(), list(), Keyword.t()) :: GoogleApi.BigQuery.V2.Model.Table.t()
+  def new(name, columns, opts) do
+    %GoogleApi.BigQuery.V2.Model.Table{
+      tableReference: reference_new(project_id(), dataset_id(), name),
+      schema: %GoogleApi.BigQuery.V2.Model.TableSchema{fields: Column.new(columns)},
+      clustering: opts[:clustering],
+      creationTime: opts[:creationTime],
+      description: opts[:description],
+      encryptionConfiguration: opts[:encryptionConfiguration],
+      etag: opts[:etag],
+      expirationTime: opts[:expirationTime],
+      externalDataConfiguration: opts[:externalDataConfiguration],
+      friendlyName: opts[:friendlyName],
+      id: opts[:id],
+      kind: opts[:kind],
+      labels: opts[:labels],
+      lastModifiedTime: opts[:lastModifiedTime],
+      location: opts[:location],
+      materializedView: opts[:materializedView],
+      model: opts[:model],
+      numBytes: opts[:nte],
+      numLongTermBytes: opts[:numLongTermBytes],
+      numPhysicalBytes: opts[:numPhysicalBytes],
+      numRows: opts[:numRows],
+      rangePartitioning: opts[:rangePartitioning],
+      requirePartitionFilter: opts[:requirePartitionFilter],
+      selfLink: opts[:selfLink],
+      snapshotDefinition: opts[:snapshotDefinition],
+      streamingBuffer: opts[:streamingBuffer],
+      timePartitioning: opts[:timePartitioning], # これ
+      type: opts[:type],
+      view: opts[:view]
+    }
+  end
+
   @spec reference_new(String.t(), String.t(), String.t()) :: GoogleApi.BigQuery.V2.Model.TableReference.t()
   defp reference_new(project_id, dataset_id, name) do
     %GoogleApi.BigQuery.V2.Model.TableReference{
@@ -268,7 +303,7 @@ defmodule Blanton.Table do
   update("TABLE_NAME", Table.new())
   """
   @spec update(String.t(), Table.t()) :: GoogleApi.BigQuery.V2.Model.TableRefence.t()
-  def update(table_id, table), do:  update(project_id(), dataset_id(), table_id, table)
+  def update(table_id, table), do: update(project_id(), dataset_id(), table_id, table)
 
   @doc """
   delete specific Table

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Blanton.MixProject do
   def project do
     [
       app: :blanton,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.10",
       description: "Blanton is a BigQuery library written by Elixir.",
       start_permanent: Mix.env() == :prod,

--- a/test/blanton_test.exs
+++ b/test/blanton_test.exs
@@ -1,3 +1,7 @@
 defmodule BlantonTest do
   use ExUnit.Case
+
+  test "version" do
+    assert Blanton.version == "0.1.1"
+  end
 end


### PR DESCRIPTION
## About
* usable options when table create

## Usage

* Create schema file like this↓.
```elixir
defmodule YourApp.BqSchema.TABLE_NAME do
  use Blanton.Schema

  schema :TABLE_NAME do
    field :name, :string, :required
  end

  options do
    register :timePartitioning, %GoogleApi.BigQuery.V2.Model.TimePartitioning{type: "DAY"}
  end
end
```

* run `mix bq.migrate`
* You can create table using specified some options!
